### PR TITLE
fix: scrobble on listened time, not seek position (#9)

### DIFF
--- a/foobar2000/foo_mac_scrobble/play_callback.cpp
+++ b/foobar2000/foo_mac_scrobble/play_callback.cpp
@@ -24,7 +24,9 @@ class scrobble_callback : public play_callback_static
     LastfmApi::TrackInfo m_current_track;
     double m_length = 0;
     double m_threshold = 0;
+    double m_listened = 0; // accumulated real listened time (seconds), not position
     bool m_scrobbled = false;
+    bool m_seek_pending = false; // drop the display tick a seek may emit
 
   public:
     unsigned get_flags() override
@@ -45,6 +47,8 @@ class scrobble_callback : public play_callback_static
         try
         {
             m_scrobbled = false;
+            m_listened = 0;
+            m_seek_pending = false;
             static_api_ptr_t<playback_control> playback_control;
             if (!playback_control->is_playing())
                 return;
@@ -133,11 +137,30 @@ class scrobble_callback : public play_callback_static
 
     void on_playback_time(double p_time) override
     {
-        if (!cfg_enabled.get() || m_scrobbled || p_time < m_threshold)
+        (void)p_time; // decision uses listened time, not playback position
+
+        if (!cfg_enabled.get() || m_scrobbled)
             return;
 
         // Don't scrobble if current track data is empty (e.g., after switching to radio streams)
         if (m_current_track.artist.empty() || m_current_track.track.empty())
+            return;
+
+        // Must guard here: on_playback_new_track sets m_threshold before its own
+        // 30s early-return, leaving a small stale threshold a short track would cross.
+        if (m_length < 30.0)
+            return;
+
+        // Drop the display tick a seek may emit, so scrubbing isn't counted as listened.
+        if (m_seek_pending)
+        {
+            m_seek_pending = false;
+            return;
+        }
+
+        // One tick ~= one second of real playback; seeks add no ticks.
+        m_listened += 1.0;
+        if (m_listened < m_threshold)
             return;
 
         try
@@ -146,9 +169,8 @@ class scrobble_callback : public play_callback_static
             if (!playback_control->is_playing())
                 return;
 
-            // Prepare the track for scrobbling
+            // copy already carries the start-of-play timestamp from on_playback_new_track
             auto copy = m_current_track;
-            copy.timestamp = time(nullptr) - static_cast<time_t>(p_time);
 
             if (g_lastfm_api && g_lastfm_api->has_saved_session() && g_scrobble_queue)
             {
@@ -171,11 +193,10 @@ class scrobble_callback : public play_callback_static
 
     void on_playback_seek(double p_time) override
     {
-        // If seeked back below threshold, allow re-scrobble
-        if (p_time < m_threshold)
-        {
-            m_scrobbled = false;
-        }
+        // A seek must not advance listened time; drop the next tick. No re-arm of
+        // m_scrobbled — one scrobble per play.
+        (void)p_time;
+        m_seek_pending = true;
     }
 
     void on_playback_stop(play_control::t_stop_reason p_reason) override
@@ -183,6 +204,8 @@ class scrobble_callback : public play_callback_static
         m_scrobbled = false;
         m_length = 0;
         m_threshold = 0;
+        m_listened = 0;
+        m_seek_pending = false;
         // Clear current track data to prevent stale data from being used
         m_current_track = LastfmApi::TrackInfo();
     }


### PR DESCRIPTION
## Problem

Closes #9. A track was scrobbled when the user dragged the seek bar to (or near) the end, even though they barely listened to it. The scrobble decision compared the playback **position** (`on_playback_time`'s `p_time`) to the threshold, so a forward seek past the threshold scrobbled instantly — and this applied to a seek to *any* point past the bar, not only the end.

## Fix

Measure **actual listened time** instead of position. `on_playback_time` is called once per second of real playback, and seeking does not generate ticks, so counting ticks is a direct, seek-immune measure of how much was listened. The existing `cfg_scrobble_percent` threshold (`min(percent% × length, 240s)`, 30s minimum) is unchanged.

- `on_playback_time`: accumulate listened seconds and compare to the threshold; ignore playback position. `m_threshold` before its own 30s early-return, leaving a small stale value a short track would otherwise cross).
- `on_playback_seek`: drop the single display tick a seek may emit (so even repeated scrubbing isn't counted); no backward-seek re-arm — one scrobble per play, matching Last.fm.
- Timestamp: use the start-of-play time captured at track start (correct even after seeks), replacing `now - position`.

The **"Scrobble after listening to: N%"** preferences slider is preserved and still drives the threshold.

## Testing

- clang-format clean; builds via existing CI.
- Manual (the seek-bar drag can't be reproduced in CI):
  - drag to the end → no scrobble ✅
  - drag to ~60% → no scrobble ✅
  - repeated scrubbing → no scrobble ✅
  - normal full play → scrobbles once, sane timestamp ✅
  - change slider % → scrobble point moves ✅
  - short (<30s) → never; long → scrobbles at the 4-min cap ✅

## Follow-up

Version bump to 0.1.5 will land as a separate commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scrobbling accuracy on macOS by refining playback time calculations. The system now properly excludes time spent seeking or scrubbing through tracks from listened duration totals. Improved state management ensures clean resets when tracks start and stop, resulting in more accurate scrobbling decisions overall.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avelytchko/foo_mac_scrobble/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->